### PR TITLE
Update firebase analytics for latest Dart 2.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cloud_firestore: 
   flutter_staggered_grid_view:
   firebase_admob: ^0.5.2
-  firebase_analytics: ^0.2.3
+  firebase_analytics: ^1.0.6
 
 
 dev_dependencies:


### PR DESCRIPTION
Fixed Error
`Because flutfire depends on firebase_analytics >=0.0.2 <0.3.0 which requires SDK version >=1.8.0 <2.0.0, version solving failed.`

@iampawan 