### PR TITLE
_getImageSize function modified [ it was showing heavy error in new f…

### DIFF
--- a/lib/mlkit/ml_detail.dart
+++ b/lib/mlkit/ml_detail.dart
@@ -216,10 +216,14 @@ class _MLDetailState extends State<MLDetail> {
   }
 
   Future<Size> _getImageSize(Image image) {
-    Completer<Size> completer = Completer<Size>();
+    Completer<Size> completer = new Completer<Size>();
     image.image.resolve(ImageConfiguration()).addListener(
-        (ImageInfo info, bool _) => completer.complete(
-            Size(info.image.width.toDouble(), info.image.height.toDouble())));
+        ImageStreamListener((ImageInfo info, bool _)
+        {
+          completer.complete(
+            Size(info.image.width.toDouble(), info.image.height.toDouble())
+          );
+        }));
     return completer.future;
   }
 }


### PR DESCRIPTION
…lutter(Dart) version ]

The code broke on line .addListener(..)
In the new version of Flutter[dart], it is showing an unpredictable Error. I solved it by using ImageStreamListener.
It is working for me fine. it is also working with all versions.

I solved creating an ImageListener function that does the same as my previous function with the listener variable. And then create an ImageStreamListener that receives this ImageListener as parameter. Note also that you can send as parameters onError and onChunk to the ImageStreamListener.